### PR TITLE
Fix test path and prop defaults

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+import App from './components/App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/PlaceView.js
+++ b/src/components/PlaceView.js
@@ -79,7 +79,7 @@ PlaceView.propTypes = {
 };
 
 PlaceView.defaultProps = {
-  gettingNextPlace: 'false',
+  gettingNextPlace: false,
   getNextPlace: noop,
   handleLunchClick: noop,
 };


### PR DESCRIPTION
## Summary
- fix broken App import in tests
- correct default prop type for `gettingNextPlace`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881b8fe4308832c8884c6d51f3b7b32