### PR TITLE
Fix location success path

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -63,7 +63,8 @@ class App extends Component {
 
 
   handleLocationSuccess = (position) => {
-    this.loadPlaces({ll: position.coords.latitude + ',' + position.coords.longitude});
+    this.loadPlaces({ll: position.coords.latitude + ',' + position.coords.longitude})
+      .then(() => this.loadPlaceDetails(0));
   }
 
   // upon failure, try and get rough location
@@ -76,6 +77,7 @@ class App extends Component {
         return response.json();
     })
     .then((location) => this.loadPlaces({ll: location.loc}))
+    .then(() => this.loadPlaceDetails(0))
     .catch(console.log);
     alert("Please allow location access. Using rough location.");
   }


### PR DESCRIPTION
## Summary
- automatically load the first place's details after successfully loading nearby places
- do the same for rough-IP location fallback

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module './App')*

------
https://chatgpt.com/codex/tasks/task_e_68870cc6bbe0832cbb3b87a1f7262188